### PR TITLE
Disable tpolecat temporarily & Fix compile issues

### DIFF
--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/ArrayUtils.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/ArrayUtils.scala
@@ -6766,7 +6766,7 @@ object ArrayUtils {
     * @param array the array to get a toString for, may be {@code null}
     * @return a String representation of the array, '{}' if null array input
     */
-  def toString(array: Any): String = toString(array, "{}")
+  def toString(array: AnyRef): String = toString(array, "{}")
 
   /**
     * <p>Outputs an array as a String handling {@code null}s.
@@ -6780,7 +6780,7 @@ object ArrayUtils {
     * @param stringIfNull the String to return if the array is {@code null}
     * @return a String representation of the array
     */
-  def toString(array: Any, stringIfNull: String): String = {
+  def toString(array: AnyRef, stringIfNull: String): String = {
     if (array == null) return stringIfNull
 
     new ToStringBuilder(array, ToStringStyle.SIMPLE_STYLE).append(array).toString

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/ClassUtils.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/ClassUtils.scala
@@ -104,7 +104,10 @@ object ClassUtils {
   /**
     * Maps wrapper {@code Class}es to their corresponding primitive types.
     */
-  private val wrapperPrimitiveMap: Map[Class[_], Class[_]] = ???
+  private val wrapperPrimitiveMap: Map[Class[_], Class[_]] = {
+    //???
+    Map.empty
+  }
 /*
     private static final Map<Class<?>, Class<?>> wrapperPrimitiveMap = new HashMap<>();
     static {
@@ -214,8 +217,8 @@ object ClassUtils {
       if (reverseAbbreviationMap.contains(_className))
         _className = reverseAbbreviationMap(_className)
     }
-    val lastDotIdx = _className.lastIndexOf(PACKAGE_SEPARATOR_CHAR)
-    val innerIdx = _className.indexOf(INNER_CLASS_SEPARATOR_CHAR,
+    val lastDotIdx = _className.lastIndexOf(PACKAGE_SEPARATOR_CHAR.toInt)
+    val innerIdx = _className.indexOf(INNER_CLASS_SEPARATOR_CHAR.toInt,
       if (lastDotIdx == -1) 0
       else lastDotIdx + 1
     )
@@ -360,7 +363,7 @@ object ClassUtils {
     while (_className.charAt(0) == '[') _className = _className.substring(1)
     if (_className.charAt(0) == 'L' && _className.charAt(_className.length - 1) == ';')
       _className = _className.substring(1)
-    val i = _className.lastIndexOf(PACKAGE_SEPARATOR_CHAR)
+    val i = _className.lastIndexOf(PACKAGE_SEPARATOR_CHAR.toInt)
     if (i == -1) return StringUtils.EMPTY
     _className.substring(0, i)
   }
@@ -912,7 +915,7 @@ object ClassUtils {
   } catch {
     case ex: ClassNotFoundException =>
       // allow path separators (.) as inner class name separators
-      val lastDotIndex = className.lastIndexOf(PACKAGE_SEPARATOR_CHAR)
+      val lastDotIndex = className.lastIndexOf(PACKAGE_SEPARATOR_CHAR.toInt)
       if (lastDotIndex != -1) try {
         return getClass(classLoader, className.substring(0, lastDotIndex) + INNER_CLASS_SEPARATOR_CHAR + className.substring(lastDotIndex + 1), initialize)
       } catch {
@@ -1309,9 +1312,9 @@ object ClassUtils {
           result
         }
 
-        def remove(): Unit = {
-          throw new UnsupportedOperationException
-        }
+//        def remove(): Unit = {
+//          throw new UnsupportedOperationException
+//        }
       }
     }
 
@@ -1326,7 +1329,7 @@ object ClassUtils {
       override val iterator: Iterator[Class[_]] = new Iterator[Class[_]] {
         override def hasNext: Boolean = return interfaces.hasNext || wrapped.hasNext
 
-        override def next: Class[_] = {
+        override def next(): Class[_] = {
           if (interfaces.hasNext) {
             val nextInterface = interfaces.next
             seenInterfaces.add(nextInterface)
@@ -1347,7 +1350,7 @@ object ClassUtils {
           }
         }
 
-        def remove(): Unit = throw new UnsupportedOperationException
+//        def remove(): Unit = throw new UnsupportedOperationException
       }
     }
   }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/StringUtils.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/StringUtils.scala
@@ -24,7 +24,7 @@ package org.apache.commons.lang3
 import java.util.Locale
 //import java.util.Objects
 //import java.util.function.Supplier
-import java.util.regex.Pattern
+//import java.util.regex.Pattern
 
 /**
   * <p>Operations on {@link java.lang.String} that are

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/EqualsBuilder.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/EqualsBuilder.scala
@@ -17,8 +17,6 @@
 
 package org.apache.commons.lang3.builder
 
-import java.lang.reflect.AccessibleObject
-import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import java.lang.{Boolean => JavaBoolean, Double => JavaDouble, Float => JavaFloat}
 import java.util
@@ -320,7 +318,8 @@ object EqualsBuilder {
     */
   def reflectionEquals(lhs: Any, rhs: Any, testTransients: Boolean, reflectUpToClass: Class[_], testRecursive: Boolean, excludeFields: String*): Boolean = {
     //if (lhs eq rhs) return true
-    ???
+    assert(false, "unimplemented")
+    //???
     if (lhs == null || rhs == null) return false
     new EqualsBuilder()
       .setExcludeFields(excludeFields:_*)
@@ -455,7 +454,8 @@ class EqualsBuilder()
   def reflectionAppend(lhs: Any, rhs: Any): EqualsBuilder = {
     if (!_isEquals) return this
     //if (lhs eq rhs) return this
-    assert(???,  "unimplemented")
+    assert(false, "unimplemented")
+    //???
     if (lhs == null || rhs == null) {
       _isEquals = false
       return this
@@ -497,7 +497,7 @@ class EqualsBuilder()
         }
       }
     } catch {
-      case e: IllegalArgumentException =>
+      case _: IllegalArgumentException =>
         // In this case, we tried to test a subclass vs. a superclass and
         // the subclass has ivars or the ivars are transient and
         // we are testing transients.
@@ -574,7 +574,8 @@ class EqualsBuilder()
   def append(lhs: Any, rhs: Any): EqualsBuilder = {
     if (!_isEquals) return this
     //if (lhs eq rhs) return this
-    assert(???, "unimplemented")
+    assert(false, "unimplemented")
+    //???
     if (lhs == null || rhs == null) {
       this.setEquals(false)
       return this

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/HashCodeBuilder.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/HashCodeBuilder.scala
@@ -17,12 +17,10 @@
 
 package org.apache.commons.lang3.builder
 
-import java.lang.{Byte => JavaByte, Double => JavaDouble, Float => JavaFloat, Short => JavaShort}
-import java.lang.reflect.AccessibleObject
+import java.lang.{Double => JavaDouble, Float => JavaFloat}
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import java.util
-import java.util.Comparator
 import org.apache.commons.lang3.ArrayUtils
 import org.apache.commons.lang3.Validate
 
@@ -178,7 +176,7 @@ object HashCodeBuilder {
           val fieldValue = field.get(`object`)
           builder.append(fieldValue)
         } catch {
-          case e: IllegalAccessException =>
+          case _: IllegalAccessException =>
             // this can't happen. Would get a Security exception instead
             // throw a runtime exception in case the impossible happens.
             throw new InternalError("Unexpected IllegalAccessException")
@@ -461,6 +459,7 @@ object HashCodeBuilder {
       REGISTRY.set(registry)
     }
     registry.add(new IDKey(value))
+    ()
   }
 
   /**
@@ -518,7 +517,7 @@ class HashCodeBuilder()
     * @throws IllegalArgumentException
     * if the number is even
     */
-  def this(initialOddNumber: Int, multiplierOddNumber: Int) {
+  def this(initialOddNumber: Int, multiplierOddNumber: Int) = {
     this()
     Validate.isTrue(initialOddNumber % 2 != 0, "HashCodeBuilder requires an odd initial value")
     Validate.isTrue(multiplierOddNumber % 2 != 0, "HashCodeBuilder requires an odd multiplier")
@@ -796,6 +795,7 @@ class HashCodeBuilder()
     else { // Not an array of primitives
       append(`object`.asInstanceOf[Array[AnyRef]])
     }
+    ()
   }
 
   /**

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ReflectionToStringBuilder.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ReflectionToStringBuilder.scala
@@ -17,15 +17,12 @@
 
 package org.apache.commons.lang3.builder
 
-import java.lang.reflect.AccessibleObject
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import java.util
-import java.util.Comparator
 import org.apache.commons.lang3.ArrayUtils
 import org.apache.commons.lang3.ClassUtils
 import org.apache.commons.lang3.Validate
-import scala.collection.JavaConverters._
 
 /**
   * <p>
@@ -453,7 +450,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
     */
   private var upToClass: Class[_] = null
 
-  def this() {
+  def this() = {
     this(null.asInstanceOf[Nothing], null, null)
   }
 
@@ -471,7 +468,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
     * @throws IllegalArgumentException
     * if the Object passed in is {@code null}
     */
-  def this(`object`: T) {
+  def this(`object`: T) = {
     this(`object`, null, null)
   }
 
@@ -491,7 +488,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
     * @throws IllegalArgumentException
     * if the Object passed in is {@code null}
     */
-  def this(`object`: T, style: ToStringStyle) {
+  def this(`object`: T, style: ToStringStyle) = {
     this(`object`, style, null)
   }
 
@@ -519,7 +516,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
     reflectUpToClass: Class[_ >: T],
     outputTransients: Boolean,
     outputStatics: Boolean
-  ) {
+  ) = {
     this(`object`, style, buffer)
     this.setUpToClass(reflectUpToClass)
     this.setAppendTransients(outputTransients)
@@ -545,7 +542,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
     *          whether to exclude fields who value is null
     * @since 3.6
     */
-  def this(`object`: T, style: ToStringStyle, buffer: StringBuffer, reflectUpToClass: Class[_ >: T], outputTransients: Boolean, outputStatics: Boolean, excludeNullValues: Boolean) {
+  def this(`object`: T, style: ToStringStyle, buffer: StringBuffer, reflectUpToClass: Class[_ >: T], outputTransients: Boolean, outputStatics: Boolean, excludeNullValues: Boolean) = {
     this(`object`, style, buffer)
     this.setUpToClass(reflectUpToClass)
     this.setAppendTransients(outputTransients)
@@ -566,7 +563,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
     * @return Whether or not to append the given {@code Field}.
     */
   protected def accept(field: Field): Boolean = {
-    if (field.getName.indexOf(ClassUtils.INNER_CLASS_SEPARATOR_CHAR) != -1) false // Reject field from inner class.
+    if (field.getName.indexOf(ClassUtils.INNER_CLASS_SEPARATOR_CHAR.toInt) != -1) false // Reject field from inner class.
     else if (Modifier.isTransient(field.getModifiers) && !this.isAppendTransients) false // Reject transient fields.
     else if (Modifier.isStatic(field.getModifiers) && !this.isAppendStatics) false // Reject static fields.
     else if (this.excludeFieldNames != null && util.Arrays.binarySearch(this.excludeFieldNames.map{ s: String => s: Object }, field.getName) >= 0) false // Reject fields from the getExcludeFieldNames list.

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ReflectionToStringBuilder.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ReflectionToStringBuilder.scala
@@ -121,7 +121,7 @@ object ReflectionToStringBuilder {
     * @see ToStringExclude
     * @see ToStringSummary
     */
-  def toString(`object`: Any): String = toString(`object`, null, false, false, null)
+  def toString(`object`: AnyRef): String = toString(`object`, null, false, false, null)
 
   /**
     * <p>
@@ -153,7 +153,7 @@ object ReflectionToStringBuilder {
     * @see ToStringExclude
     * @see ToStringSummary
     */
-  def toString(`object`: Any, style: ToStringStyle): String = toString(`object`, style, false, false, null)
+  def toString(`object`: AnyRef, style: ToStringStyle): String = toString(`object`, style, false, false, null)
 
   /**
     * <p>
@@ -191,7 +191,7 @@ object ReflectionToStringBuilder {
     * @see ToStringExclude
     * @see ToStringSummary
     */
-  def toString(`object`: Any, style: ToStringStyle, outputTransients: Boolean): String = toString(`object`, style, outputTransients, false, null)
+  def toString(`object`: AnyRef, style: ToStringStyle, outputTransients: Boolean): String = toString(`object`, style, outputTransients, false, null)
 
   /**
     * <p>
@@ -237,7 +237,7 @@ object ReflectionToStringBuilder {
     * @see ToStringSummary
     * @since 2.1
     */
-  def toString(`object`: Any, style: ToStringStyle, outputTransients: Boolean, outputStatics: Boolean): String = toString(`object`, style, outputTransients, outputStatics, null)
+  def toString(`object`: AnyRef, style: ToStringStyle, outputTransients: Boolean, outputStatics: Boolean): String = toString(`object`, style, outputTransients, outputStatics, null)
 
   /**
     * <p>
@@ -288,7 +288,7 @@ object ReflectionToStringBuilder {
     * @see ToStringSummary
     * @since 2.1
     */
-  def toString[T](`object`: T, style: ToStringStyle, outputTransients: Boolean, outputStatics: Boolean, reflectUpToClass: Class[_ >: T]): String = new ReflectionToStringBuilder(`object`, style, null, reflectUpToClass, outputTransients, outputStatics).toString
+  def toString[T <: AnyRef](`object`: T, style: ToStringStyle, outputTransients: Boolean, outputStatics: Boolean, reflectUpToClass: Class[_ >: T]): String = new ReflectionToStringBuilder(`object`, style, null, reflectUpToClass, outputTransients, outputStatics).toString
 
   /**
     * <p>
@@ -341,7 +341,7 @@ object ReflectionToStringBuilder {
     * @see ToStringSummary
     * @since 3.6
     */
-  def toString[T](`object`: T, style: ToStringStyle, outputTransients: Boolean, outputStatics: Boolean, excludeNullValues: Boolean, reflectUpToClass: Class[_ >: T]): String =
+  def toString[T <: AnyRef](`object`: T, style: ToStringStyle, outputTransients: Boolean, outputStatics: Boolean, excludeNullValues: Boolean, reflectUpToClass: Class[_ >: T]): String =
     new ReflectionToStringBuilder(`object`, style, null, reflectUpToClass, outputTransients, outputStatics, excludeNullValues).toString
 
   /**
@@ -353,7 +353,7 @@ object ReflectionToStringBuilder {
     * The field names to exclude. Null excludes nothing.
     * @return The toString value.
     */
-  def toStringExclude(`object`: Any, excludeFieldNames: util.Collection[String]): String =
+  def toStringExclude(`object`: AnyRef, excludeFieldNames: util.Collection[String]): String =
     toStringExclude(`object`, toNoNullStringArray(excludeFieldNames):_*)
 
   /**
@@ -379,7 +379,7 @@ object ReflectionToStringBuilder {
     * The array to check
     * @return The given array or a new array without null.
     */
-  private[builder] def toNoNullStringArray(array: Array[Any]): Array[String] = {
+  private[builder] def toNoNullStringArray(array: Array[AnyRef]): Array[String] = {
     val list = new util.ArrayList[String](array.length)
     for (e <- array) {
       if (e != null) list.add(e.toString)
@@ -396,12 +396,12 @@ object ReflectionToStringBuilder {
     * The field names to exclude
     * @return The toString value.
     */
-  def toStringExclude(`object`: Any, excludeFieldNames: String*): String =
+  def toStringExclude(`object`: AnyRef, excludeFieldNames: String*): String =
     new ReflectionToStringBuilder(`object`)
       .setExcludeFieldNames(excludeFieldNames:_*)
       .toString
 
-  private def checkNotNull(obj: Any) = Validate.notNull(obj, "The Object passed in should not be null.")
+  private def checkNotNull(obj: AnyRef): AnyRef = Validate.notNull(obj, "The Object passed in should not be null.")
 }
 
 /**
@@ -428,7 +428,7 @@ object ReflectionToStringBuilder {
   * @throws IllegalArgumentException
   * if the Object passed in is {@code null}
   */
-class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: StringBuffer)
+class ReflectionToStringBuilder[T <: AnyRef](`object`: T, style: ToStringStyle, buffer: StringBuffer)
   extends ToStringBuilder(ReflectionToStringBuilder.checkNotNull(`object`), style, buffer) {
   /**
     * Whether or not to append static fields.
@@ -586,7 +586,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
     * @param clazz
     * The class of object parameter
     */
-  protected def appendFieldsIn(clazz: Class[_]): Unit = {
+  protected def appendFieldsIn(clazz: Class[AnyRef]): Unit = {
     if (clazz.isArray) {
       this.reflectionAppendArray(this.getObject)
       return
@@ -599,7 +599,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
       val fieldName = field.getName
       if (this.accept(field)) try { // Warning: Field.get(Object) creates wrappers objects
         // for primitive types.
-        val fieldValue = this.getValue(field)
+        val fieldValue = this.getValue(field).asInstanceOf[AnyRef]
         if (!excludeNullValues || fieldValue != null) this.append(fieldName, fieldValue, !field.isAnnotationPresent(classOf[ToStringSummary]))
       } catch {
         case ex: IllegalAccessException =>
@@ -679,7 +679,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
     * the array to add to the {@code toString}
     * @return this
     */
-  def reflectionAppendArray(array: Any): ReflectionToStringBuilder[_] = {
+  def reflectionAppendArray(array: AnyRef): ReflectionToStringBuilder[_] = {
     this.getStyle.reflectionAppendArrayDetail(this.getStringBuffer, null, array)
     this
   }
@@ -732,7 +732,7 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
   def setExcludeFieldNames(excludeFieldNamesParam: String*): ReflectionToStringBuilder[_] = {
     if (excludeFieldNamesParam == null) this.excludeFieldNames = null
     else { //clone and remove nulls
-      this.excludeFieldNames = ReflectionToStringBuilder.toNoNullStringArray(excludeFieldNamesParam.toArray: Array[Any]).sorted
+      this.excludeFieldNames = ReflectionToStringBuilder.toNoNullStringArray(excludeFieldNamesParam.toArray: Array[AnyRef]).sorted
     }
     this
   }
@@ -762,12 +762,12 @@ class ReflectionToStringBuilder[T](`object`: T, style: ToStringStyle, buffer: St
     */
   override def toString: String = {
     if (this.getObject == null) return this.getStyle.getNullText
-    var clazz = this.getObject.getClass
+    var clazz = this.getObject.getClass.asInstanceOf[Class[AnyRef]]
     this.appendFieldsIn(clazz)
     while ( {
       clazz.getSuperclass != null && (clazz ne this.getUpToClass)
     }) {
-      clazz = clazz.getSuperclass
+      clazz = clazz.getSuperclass.asInstanceOf[Class[AnyRef]]
       this.appendFieldsIn(clazz)
     }
     super.toString

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ToStringBuilder.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ToStringBuilder.scala
@@ -207,7 +207,7 @@ class ToStringBuilder(`object`: Any, private var style: ToStringStyle, private v
     *
     * @param object the Object to build a {@code toString} for, not recommended to be null
     */
-  def this(`object`: Any) {
+  def this(`object`: Any) = {
     this(`object`, null, null)
   }
 
@@ -219,7 +219,7 @@ class ToStringBuilder(`object`: Any, private var style: ToStringStyle, private v
     * @param object the Object to build a {@code toString} for, not recommended to be null
     * @param style  the style of the {@code toString} to create, null uses the default style
     */
-  def this(`object`: Any, style: ToStringStyle) {
+  def this(`object`: Any, style: ToStringStyle) = {
     this(`object`, style, null)
   }
 

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ToStringBuilder.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ToStringBuilder.scala
@@ -141,7 +141,7 @@ object ToStringBuilder {
     * @return the String result
     * @see ReflectionToStringBuilder#toString(Object)
     */
-  def reflectionToString(`object`: Any): String = ReflectionToStringBuilder.toString(`object`)
+  def reflectionToString(`object`: AnyRef): String = ReflectionToStringBuilder.toString(`object`)
 
   /**
     * <p>Uses {@code ReflectionToStringBuilder} to generate a
@@ -152,7 +152,7 @@ object ToStringBuilder {
     * @return the String result
     * @see ReflectionToStringBuilder#toString(Object,ToStringStyle)
     */
-  def reflectionToString(`object`: Any, style: ToStringStyle): String = ReflectionToStringBuilder.toString(`object`, style)
+  def reflectionToString(`object`: AnyRef, style: ToStringStyle): String = ReflectionToStringBuilder.toString(`object`, style)
 
   /**
     * <p>Uses {@code ReflectionToStringBuilder} to generate a
@@ -164,7 +164,7 @@ object ToStringBuilder {
     * @return the String result
     * @see ReflectionToStringBuilder#toString(Object,ToStringStyle,boolean)
     */
-  def reflectionToString(`object`: Any, style: ToStringStyle, outputTransients: Boolean): String = ReflectionToStringBuilder.toString(`object`, style, outputTransients, false, null)
+  def reflectionToString(`object`: AnyRef, style: ToStringStyle, outputTransients: Boolean): String = ReflectionToStringBuilder.toString(`object`, style, outputTransients, false, null)
 
   /**
     * <p>Uses {@code ReflectionToStringBuilder} to generate a
@@ -179,7 +179,7 @@ object ToStringBuilder {
     * @see ReflectionToStringBuilder#toString(Object,ToStringStyle,boolean,boolean,Class)
     * @since 2.0
     */
-  def reflectionToString[T](`object`: T, style: ToStringStyle, outputTransients: Boolean, reflectUpToClass: Class[_ >: T]): String = ReflectionToStringBuilder.toString(`object`, style, outputTransients, false, reflectUpToClass)
+  def reflectionToString[T <: AnyRef](`object`: T, style: ToStringStyle, outputTransients: Boolean, reflectUpToClass: Class[_ >: T]): String = ReflectionToStringBuilder.toString(`object`, style, outputTransients, false, reflectUpToClass)
 }
 
 
@@ -194,7 +194,7 @@ object ToStringBuilder {
   * @param style  the style of the {@code toString} to create, null uses the default style
   * @param buffer the {@code StringBuffer} to populate, may be null
   */
-class ToStringBuilder(`object`: Any, private var style: ToStringStyle, private var buffer: StringBuffer)
+class ToStringBuilder(`object`: AnyRef, private var style: ToStringStyle, private var buffer: StringBuffer)
   extends Builder[String] {
   if (style == null) style = ToStringBuilder.getDefaultStyle
   if (buffer == null) buffer = new StringBuffer(512)
@@ -207,7 +207,7 @@ class ToStringBuilder(`object`: Any, private var style: ToStringStyle, private v
     *
     * @param object the Object to build a {@code toString} for, not recommended to be null
     */
-  def this(`object`: Any) {
+  def this(`object`: AnyRef) {
     this(`object`, null, null)
   }
 
@@ -219,7 +219,7 @@ class ToStringBuilder(`object`: Any, private var style: ToStringStyle, private v
     * @param object the Object to build a {@code toString} for, not recommended to be null
     * @param style  the style of the {@code toString} to create, null uses the default style
     */
-  def this(`object`: Any, style: ToStringStyle) {
+  def this(`object`: AnyRef, style: ToStringStyle) {
     this(`object`, style, null)
   }
 
@@ -398,7 +398,7 @@ class ToStringBuilder(`object`: Any, private var style: ToStringStyle, private v
     * @param obj the value to add to the {@code toString}
     * @return this
     */
-  def append(obj: Any): ToStringBuilder = {
+  def append(obj: AnyRef): ToStringBuilder = {
     style.append(buffer, null, obj, null.asInstanceOf[Boolean])
     this
   }
@@ -768,7 +768,7 @@ class ToStringBuilder(`object`: Any, private var style: ToStringStyle, private v
     * @param obj       the value to add to the {@code toString}
     * @return this
     */
-  def append(fieldName: String, obj: Any): ToStringBuilder = {
+  def append(fieldName: String, obj: AnyRef): ToStringBuilder = {
     style.append(buffer, fieldName, obj, null.asInstanceOf[Boolean])
     this
   }
@@ -783,7 +783,7 @@ class ToStringBuilder(`object`: Any, private var style: ToStringStyle, private v
     *                   {@code false} for summary info
     * @return this
     */
-  def append(fieldName: String, obj: Any, fullDetail: Boolean): ToStringBuilder = {
+  def append(fieldName: String, obj: AnyRef, fullDetail: Boolean): ToStringBuilder = {
     style.append(buffer, fieldName, obj, JavaBoolean.valueOf(fullDetail))
     this
   }
@@ -936,7 +936,7 @@ class ToStringBuilder(`object`: Any, private var style: ToStringStyle, private v
     * @return The object being output.
     * @since 2.0
     */
-  def getObject: Any = `object`
+  def getObject: AnyRef = `object`
 
   /**
     * <p>Gets the {@code StringBuffer} being populated.</p>

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ToStringStyle.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ToStringStyle.scala
@@ -195,6 +195,7 @@ object ToStringStyle {
       if (m == null) REGISTRY.set(new util.WeakHashMap[Any, Any])
       getRegistry.put(value, null)
     }
+    ()
   }
 
   /**
@@ -475,6 +476,7 @@ object ToStringStyle {
         return
       }
       buffer.append(map)
+      ()
     }
 
     private def isJsonArray(valueAsString: String) = valueAsString.startsWith(getArrayStart) && valueAsString.endsWith(getArrayEnd)
@@ -489,6 +491,7 @@ object ToStringStyle {
       */
     private def appendValueAsString(buffer: StringBuffer, value: String): Unit = {
       buffer.append('"').append(StringEscapeUtils.escapeJson(value)).append('"')
+      ()
     }
 
     override protected def appendFieldStart(buffer: StringBuffer, fieldName: String): Unit = {
@@ -768,6 +771,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Any): Unit = {
     buffer.append(value)
+    ()
   }
 
   /**
@@ -792,6 +796,7 @@ abstract class ToStringStyle protected()
       return
     }
     buffer.append(coll)
+    ()
   }
 
   /**
@@ -804,6 +809,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, map: util.Map[_, _]): Unit = {
     buffer.append(map)
+    ()
   }
 
   /**
@@ -819,6 +825,7 @@ abstract class ToStringStyle protected()
     buffer.append(summaryObjectStartText)
     buffer.append(getShortClassName(value.getClass))
     buffer.append(summaryObjectEndText)
+    ()
   }
 
   /**
@@ -845,6 +852,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Long): Unit = {
     buffer.append(value)
+    ()
   }
 
   /**
@@ -871,6 +879,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Int): Unit = {
     buffer.append(value)
+    ()
   }
 
   /**
@@ -896,7 +905,8 @@ abstract class ToStringStyle protected()
     * @param value     the value to add to the {@code toString}
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Short): Unit = {
-    buffer.append(value)
+    buffer.append(value.toInt)
+    ()
   }
 
   /**
@@ -922,7 +932,8 @@ abstract class ToStringStyle protected()
     * @param value     the value to add to the {@code toString}
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Byte): Unit = {
-    buffer.append(value)
+    buffer.append(value.toInt)
+    ()
   }
 
   /**
@@ -949,6 +960,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Char): Unit = {
     buffer.append(value)
+    ()
   }
 
   /**
@@ -975,6 +987,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Double): Unit = {
     buffer.append(value)
+    ()
   }
 
   /**
@@ -1001,6 +1014,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Float): Unit = {
     buffer.append(value)
+    ()
   }
 
   /**
@@ -1027,6 +1041,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Boolean): Unit = {
     buffer.append(value)
+    ()
   }
 
   /**
@@ -1065,6 +1080,7 @@ abstract class ToStringStyle protected()
     }
 
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1100,6 +1116,7 @@ abstract class ToStringStyle protected()
       appendDetail(buffer, fieldName, i, item)
     }
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1149,6 +1166,7 @@ abstract class ToStringStyle protected()
       appendDetail(buffer, fieldName, array(i))
     }
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1198,6 +1216,7 @@ abstract class ToStringStyle protected()
       appendDetail(buffer, fieldName, array(i))
     }
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1247,6 +1266,7 @@ abstract class ToStringStyle protected()
       appendDetail(buffer, fieldName, array(i))
     }
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1296,6 +1316,7 @@ abstract class ToStringStyle protected()
       appendDetail(buffer, fieldName, array(i))
     }
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1345,6 +1366,7 @@ abstract class ToStringStyle protected()
       appendDetail(buffer, fieldName, array(i))
     }
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1394,6 +1416,7 @@ abstract class ToStringStyle protected()
       appendDetail(buffer, fieldName, array(i))
     }
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1443,6 +1466,7 @@ abstract class ToStringStyle protected()
       appendDetail(buffer, fieldName, array(i))
     }
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1492,6 +1516,7 @@ abstract class ToStringStyle protected()
       appendDetail(buffer, fieldName, array(i))
     }
     buffer.append(arrayEnd)
+    ()
   }
 
   /**
@@ -1519,6 +1544,7 @@ abstract class ToStringStyle protected()
       if (useShortClassName) buffer.append(getShortClassName(`object`.getClass))
       else buffer.append(`object`.getClass.getName)
     }
+    ()
   }
 
   /**
@@ -1533,6 +1559,7 @@ abstract class ToStringStyle protected()
       buffer.append('@')
       buffer.append(Integer.toHexString(System.identityHashCode(`object`)))
     }
+    ()
   }
 
   /**
@@ -1542,6 +1569,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendContentStart(buffer: StringBuffer): Unit = {
     buffer.append(contentStart)
+    ()
   }
 
   /**
@@ -1551,6 +1579,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendContentEnd(buffer: StringBuffer): Unit = {
     buffer.append(contentEnd)
+    ()
   }
 
   /**
@@ -1563,6 +1592,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendNullText(buffer: StringBuffer, fieldName: String): Unit = {
     buffer.append(nullText)
+    ()
   }
 
   /**
@@ -1572,6 +1602,7 @@ abstract class ToStringStyle protected()
     */
   protected def appendFieldSeparator(buffer: StringBuffer): Unit = {
     buffer.append(fieldSeparator)
+    ()
   }
 
   /**
@@ -1585,6 +1616,7 @@ abstract class ToStringStyle protected()
       buffer.append(fieldName)
       buffer.append(fieldNameValueSeparator)
     }
+    ()
   }
 
   /**
@@ -1616,6 +1648,7 @@ abstract class ToStringStyle protected()
     buffer.append(sizeStartText)
     buffer.append(size)
     buffer.append(sizeEndText)
+    ()
   }
 
   /**

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ToStringStyle.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/builder/ToStringStyle.scala
@@ -424,7 +424,7 @@ object ToStringStyle {
       super.append(buffer, fieldName, array, fullDetail)
     }
 
-    override def append(buffer: StringBuffer, fieldName: String, value: Any, fullDetail: Boolean): Unit = {
+    override def append(buffer: StringBuffer, fieldName: String, value: AnyRef, fullDetail: Boolean): Unit = {
       if (fieldName == null) throw new UnsupportedOperationException("Field names are mandatory when using JsonToStringStyle")
       if (!isFullDetail(fullDetail)) throw new UnsupportedOperationException("FullDetail must be true when using JsonToStringStyle")
       super.append(buffer, fieldName, value, fullDetail)
@@ -434,7 +434,7 @@ object ToStringStyle {
       appendValueAsString(buffer, String.valueOf(value))
     }
 
-    override protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Any): Unit = {
+    override protected def appendDetail(buffer: StringBuffer, fieldName: String, value: AnyRef): Unit = {
       if (value == null) {
         appendNullText(buffer, fieldName)
         return
@@ -455,7 +455,7 @@ object ToStringStyle {
       appendDetail(buffer, fieldName, valueAsString)
     }
 
-    override protected def appendDetail(buffer: StringBuffer, fieldName: String, map: util.Map[_, _]): Unit = {
+    override protected def appendDetail(buffer: StringBuffer, fieldName: String, map: util.Map[AnyRef, AnyRef]): Unit = {
       if (map != null && !map.isEmpty) {
         buffer.append(getContentStart)
         var firstItem = true
@@ -683,7 +683,7 @@ abstract class ToStringStyle protected()
     * @param fullDetail {@code true} for detail, {@code false}
     *                   for summary info, {@code null} for style decides
     */
-  def append(buffer: StringBuffer, fieldName: String, value: Any, fullDetail: Boolean): Unit = {
+  def append(buffer: StringBuffer, fieldName: String, value: AnyRef, fullDetail: Boolean): Unit = {
     appendFieldStart(buffer, fieldName)
     if (value == null) appendNullText(buffer, fieldName)
     else appendInternal(buffer, fieldName, value, isFullDetail(fullDetail))
@@ -709,7 +709,7 @@ abstract class ToStringStyle protected()
     *                  not {@code null}
     * @param detail    output detail or not
     */
-  protected def appendInternal(buffer: StringBuffer, fieldName: String, value: Any, detail: Boolean): Unit = {
+  protected def appendInternal(buffer: StringBuffer, fieldName: String, value: AnyRef, detail: Boolean): Unit = {
     if (ToStringStyle.isRegistered(value) && !(value.isInstanceOf[Number] || value.isInstanceOf[Boolean] || value.isInstanceOf[Character])) {
       appendCyclicObject(buffer, fieldName, value)
       return
@@ -753,7 +753,7 @@ abstract class ToStringStyle protected()
     *                  not {@code null}
     * @since 2.2
     */
-  protected def appendCyclicObject(buffer: StringBuffer, fieldName: String, value: Any): Unit = {
+  protected def appendCyclicObject(buffer: StringBuffer, fieldName: String, value: AnyRef): Unit = {
     ObjectUtils.identityToString(buffer, value)
   }
 
@@ -766,7 +766,7 @@ abstract class ToStringStyle protected()
     * @param value     the value to add to the {@code toString},
     *                  not {@code null}
     */
-  protected def appendDetail(buffer: StringBuffer, fieldName: String, value: Any): Unit = {
+  protected def appendDetail(buffer: StringBuffer, fieldName: String, value: AnyRef): Unit = {
     buffer.append(value)
   }
 
@@ -778,7 +778,7 @@ abstract class ToStringStyle protected()
     * @param coll      the {@code Collection} to add to the
     *                  {@code toString}, not {@code null}
     */
-  protected def appendDetail(buffer: StringBuffer, fieldName: String, coll: util.Collection[_]): Unit = {
+  protected def appendDetail(buffer: StringBuffer, fieldName: String, coll: util.Collection[AnyRef]): Unit = {
     if (coll != null && !coll.isEmpty) {
       buffer.append(arrayStart)
       var i = 0
@@ -802,7 +802,7 @@ abstract class ToStringStyle protected()
     * @param map       the {@code Map} to add to the {@code toString},
     *                  not {@code null}
     */
-  protected def appendDetail(buffer: StringBuffer, fieldName: String, map: util.Map[_, _]): Unit = {
+  protected def appendDetail(buffer: StringBuffer, fieldName: String, map: util.Map[AnyRef, AnyRef]): Unit = {
     buffer.append(map)
   }
 
@@ -815,7 +815,7 @@ abstract class ToStringStyle protected()
     * @param value     the value to add to the {@code toString},
     *                  not {@code null}
     */
-  protected def appendSummary(buffer: StringBuffer, fieldName: String, value: Any): Unit = {
+  protected def appendSummary(buffer: StringBuffer, fieldName: String, value: AnyRef): Unit = {
     buffer.append(summaryObjectStartText)
     buffer.append(getShortClassName(value.getClass))
     buffer.append(summaryObjectEndText)
@@ -1056,7 +1056,7 @@ abstract class ToStringStyle protected()
     * @param array     the array to add to the {@code toString},
     *                  not {@code null}
     */
-  protected def appendDetail(buffer: StringBuffer, fieldName: String, array: Array[_]): Unit = {
+  protected def appendDetail(buffer: StringBuffer, fieldName: String, array: Array[AnyRef]): Unit = {
     buffer.append(arrayStart)
 
     for (i <- 0 until array.length) {
@@ -1077,7 +1077,7 @@ abstract class ToStringStyle protected()
     * @param item      the array item to add
     * @since 3.11
     */
-  protected def appendDetail(buffer: StringBuffer, fieldName: String, i: Int, item: Any): Unit = {
+  protected def appendDetail(buffer: StringBuffer, fieldName: String, i: Int, item: AnyRef): Unit = {
     if (i > 0) buffer.append(arraySeparator)
     if (item == null) appendNullText(buffer, fieldName)
     else appendInternal(buffer, fieldName, item, arrayContentDetail)
@@ -1092,7 +1092,7 @@ abstract class ToStringStyle protected()
     *                  not {@code null}
     * @since 2.0
     */
-  protected[lang3] def reflectionAppendArrayDetail(buffer: StringBuffer, fieldName: String, array: Any): Unit = {
+  protected[lang3] def reflectionAppendArrayDetail(buffer: StringBuffer, fieldName: String, array: AnyRef): Unit = {
     buffer.append(arrayStart)
     val length = reflect.Array.getLength(array)
     for (i <- 0 until length) {

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/CloneFailedException.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/CloneFailedException.scala
@@ -32,7 +32,7 @@ class CloneFailedException(message: String, cause: Throwable) extends RuntimeExc
     *
     * @param message description of the exception
     */
-  def this(message: String) {
+  def this(message: String) = {
     this(message, null)
   }
 
@@ -41,14 +41,14 @@ class CloneFailedException(message: String, cause: Throwable) extends RuntimeExc
     *
     * @param cause cause of the exception
     */
-  def this(cause: Throwable) {
+  def this(cause: Throwable) = {
     this(null, cause)
   }
 
   /**
     * Constructs a CloneFailedException.
     */
-  def this() {
+  def this() = {
     this(null, null)
   }
 }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ContextException.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ContextException.scala
@@ -118,7 +118,7 @@ class ContextedException(message: String, cause: Throwable)
     * @param cause   the underlying cause of the exception, may be null
     * @param context the context used to store the additional information, null uses default implementation
     */
-  def this(message: String, cause: Throwable, context: ExceptionContext) {
+  def this(message: String, cause: Throwable, context: ExceptionContext) = {
     this(message, cause)
     if (context == null) exceptionContext = new DefaultExceptionContext
     else exceptionContext = context

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ContextException.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ContextException.scala
@@ -137,7 +137,7 @@ class ContextedException(message: String, cause: Throwable)
     * @param value information needed to understand exception, may be {@code null}
     * @return {@code this}, for method chaining, not {@code null}
     */
-  override def addContextValue(label: String, value: Any): ContextedException = {
+  override def addContextValue(label: String, value: AnyRef): ContextedException = {
     exceptionContext.addContextValue(label, value)
     this
   }
@@ -155,7 +155,7 @@ class ContextedException(message: String, cause: Throwable)
     * @param value information needed to understand exception, may be {@code null}
     * @return {@code this}, for method chaining, not {@code null}
     */
-  override def setContextValue(label: String, value: Any): ContextedException = {
+  override def setContextValue(label: String, value: AnyRef): ContextedException = {
     exceptionContext.setContextValue(label, value)
     this
   }
@@ -163,13 +163,13 @@ class ContextedException(message: String, cause: Throwable)
   /**
     * {@inheritDoc }
     */
-  override def getContextValues(label: String): util.List[Any] =
+  override def getContextValues(label: String): util.List[AnyRef] =
     this.exceptionContext.getContextValues(label)
 
-  override def getFirstContextValue(label: String): Any =
+  override def getFirstContextValue(label: String): AnyRef =
     this.exceptionContext.getFirstContextValue(label)
 
-  override def getContextEntries: util.List[Pair[String, Any]] =
+  override def getContextEntries: util.List[Pair[String, AnyRef]] =
     this.exceptionContext.getContextEntries
 
   override def getContextLabels: util.Set[String] =

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ContextedRuntimeException.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ContextedRuntimeException.scala
@@ -136,7 +136,7 @@ class ContextedRuntimeException
     * @param cause   the underlying cause of the exception, may be null
     * @param context the context used to store the additional information, null uses default implementation
     */
-  def this(message: String, cause: Throwable, context: ExceptionContext) {
+  def this(message: String, cause: Throwable, context: ExceptionContext) = {
     this(message, cause)
     if (context != null) exceptionContext = context
   }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ContextedRuntimeException.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ContextedRuntimeException.scala
@@ -154,7 +154,7 @@ class ContextedRuntimeException
     * @param value information needed to understand exception, may be {@code null}
     * @return {@code this}, for method chaining, not {@code null}
     */
-  override def addContextValue(label: String, value: Any): ContextedRuntimeException = {
+  override def addContextValue(label: String, value: AnyRef): ContextedRuntimeException = {
     exceptionContext.addContextValue(label, value)
     this
   }
@@ -172,7 +172,7 @@ class ContextedRuntimeException
     * @param value information needed to understand exception, may be {@code null}
     * @return {@code this}, for method chaining, not {@code null}
     */
-  override def setContextValue(label: String, value: Any): ContextedRuntimeException = {
+  override def setContextValue(label: String, value: AnyRef): ContextedRuntimeException = {
     exceptionContext.setContextValue(label, value)
     this
   }
@@ -180,11 +180,11 @@ class ContextedRuntimeException
   /**
     * {@inheritDoc }
     */
-  override def getContextValues(label: String): util.List[Any] = this.exceptionContext.getContextValues(label)
+  override def getContextValues(label: String): util.List[AnyRef] = this.exceptionContext.getContextValues(label)
 
-  override def getFirstContextValue(label: String): Any = this.exceptionContext.getFirstContextValue(label)
+  override def getFirstContextValue(label: String): AnyRef = this.exceptionContext.getFirstContextValue(label)
 
-  override def getContextEntries: util.List[Pair[String, Any]] = this.exceptionContext.getContextEntries
+  override def getContextEntries: util.List[Pair[String, AnyRef]] = this.exceptionContext.getContextEntries
 
   override def getContextLabels: util.Set[String] = exceptionContext.getContextLabels
 

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ExceptionContext.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/exception/ExceptionContext.scala
@@ -44,7 +44,7 @@ trait ExceptionContext {
     * @param value the value of item to add, may be {@code null}
     * @return {@code this}, for method chaining, not {@code null}
     */
-  def addContextValue(label: String, value: Any): ExceptionContext
+  def addContextValue(label: String, value: AnyRef): ExceptionContext
 
   /**
     * Sets a contextual label-value pair into this context.
@@ -57,7 +57,7 @@ trait ExceptionContext {
     * @param value the value of item to add, may be {@code null}
     * @return {@code this}, for method chaining, not {@code null}
     */
-  def setContextValue(label: String, value: Any): ExceptionContext
+  def setContextValue(label: String, value: AnyRef): ExceptionContext
 
   /**
     * Retrieves all the contextual data values associated with the label.
@@ -65,7 +65,7 @@ trait ExceptionContext {
     * @param label the label to get the contextual values for, may be {@code null}
     * @return the contextual values associated with the label, never {@code null}
     */
-  def getContextValues(label: String): util.List[Any]
+  def getContextValues(label: String): util.List[AnyRef]
 
   /**
     * Retrieves the first available contextual data value associated with the label.
@@ -73,7 +73,7 @@ trait ExceptionContext {
     * @param label the label to get the contextual value for, may be {@code null}
     * @return the first contextual value associated with the label, may be {@code null}
     */
-  def getFirstContextValue(label: String): Any
+  def getFirstContextValue(label: String): AnyRef
 
   /**
     * Retrieves the full set of labels defined in the contextual data.
@@ -87,7 +87,7 @@ trait ExceptionContext {
     *
     * @return the list of pairs, not {@code null}
     */
-  def getContextEntries: util.List[Pair[String, Any]]
+  def getContextEntries: util.List[Pair[String, AnyRef]]
 
   /**
     * Gets the contextualized error message based on a base message.

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/math/NumberUtils.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/math/NumberUtils.scala
@@ -24,7 +24,7 @@ import java.math.RoundingMode
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.Validate
 import scala.util.control.Breaks
-import java.lang.{Float => JavaFloat, Long => JavaLong}
+import java.lang.{Long => JavaLong}
 
 /**
   * <p>Provides extra functionality for Java Number classes.</p>
@@ -448,7 +448,7 @@ object NumberUtils {
     */
   def toScaledBigDecimal(value: Float, scale: Int, roundingMode: RoundingMode): BigDecimal = {
     if (value == null) return BigDecimal.ZERO
-    toScaledBigDecimal(BigDecimal.valueOf(value), scale, roundingMode)
+    toScaledBigDecimal(BigDecimal.valueOf(value.toDouble), scale, roundingMode)
   }
 
   /**
@@ -557,21 +557,20 @@ object NumberUtils {
       for (pfx: String <- hex_prefixes) {
         if (str.startsWith(pfx)) {
           pfxLen += pfx.length
-          break
+          break()
         }
       }
     }
 
     if (pfxLen > 0) { // we have a hex number
-      var firstSigDigit: Int = 0 // strip leading zeroes
+      var firstSigDigit: Char = '0' // strip leading zeroes
 
       breakable {
         for (i: Int <- pfxLen until length) {
           firstSigDigit = str.charAt(i)
           if (firstSigDigit == '0') { // count leading zeroes
             pfxLen += 1
-          }
-          else break
+          } else break()
         }
       }
 
@@ -624,7 +623,7 @@ object NumberUtils {
           if (dec == null && exp == null && (!numeric.isEmpty && numeric.charAt(0) == '-' && isDigits(numeric.substring(1)) || isDigits(numeric))) {
             try return createLong(numeric)
             catch {
-              case nfe: NumberFormatException =>
+              case _: NumberFormatException =>
 
               // NOPMD
               // Too big for a long
@@ -641,7 +640,7 @@ object NumberUtils {
               return f
             }
           } catch {
-            case nfe: NumberFormatException =>
+            case _: NumberFormatException =>
 
             // ignore the bad number
           }
@@ -652,12 +651,12 @@ object NumberUtils {
             val d = createDouble(str)
             if (!(d.isInfinite || d.floatValue == 0.0D && !(allZeros))) return d
           } catch {
-            case nfe: NumberFormatException =>
+            case _: NumberFormatException =>
 
           }
           try return createBigDecimal(numeric)
           catch {
-            case e: NumberFormatException =>
+            case _: NumberFormatException =>
 
           }
         case _ =>
@@ -670,14 +669,16 @@ object NumberUtils {
     else exp = null
     if (dec == null && exp == null) { // no decimal point and no exponent
       //Must be an Integer, Long, Biginteger
-      try return createInteger(str)
-      catch {
-        case nfe: NumberFormatException =>
+      try {
+        return createInteger(str)
+      } catch {
+        case _: NumberFormatException =>
 
       }
-      try return createLong(str)
-      catch {
-        case nfe: NumberFormatException =>
+      try {
+        return createLong(str)
+      } catch {
+        case _: NumberFormatException =>
 
       }
       return createBigInteger(str)
@@ -694,7 +695,7 @@ object NumberUtils {
         return b
       }
     } catch {
-      case nfe: NumberFormatException =>
+      case _: NumberFormatException =>
 
     }
     createBigDecimal(str)

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableBoolean.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableBoolean.scala
@@ -44,7 +44,7 @@ class MutableBoolean()
     *
     * @param value the initial value to store
     */
-  def this(value: Boolean) {
+  def this(value: Boolean) = {
     this()
     this.value = value
   }
@@ -55,7 +55,7 @@ class MutableBoolean()
     * @param value the initial value to store, not null
     * @throws NullPointerException if the object is null
     */
-  def this(value: JavaBoolean) {
+  def this(value: JavaBoolean) = {
     this()
     this.value = value.booleanValue
   }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableBoolean.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableBoolean.scala
@@ -143,7 +143,7 @@ class MutableBoolean()
     * @param obj the object to compare with, null returns false
     * @return {@code true} if the objects are the same; {@code false} otherwise.
     */
-  override def equals(obj: Any): JavaBoolean = {
+  override def equals(obj: Any): Boolean = {
     if (obj.isInstanceOf[MutableBoolean]) return value == obj.asInstanceOf[MutableBoolean].booleanValue
     false
   }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableByte.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableByte.scala
@@ -48,7 +48,7 @@ class MutableJavaByte()
     *
     * @param value the initial value to store
     */
-  def this(value: Byte) {
+  def this(value: Byte) = {
     this()
     this.value = value
   }
@@ -59,7 +59,7 @@ class MutableJavaByte()
     * @param value the initial value to store, not null
     * @throws NullPointerException if the object is null
     */
-  def this(value: Number) {
+  def this(value: Number) = {
     this()
     this.value = value.byteValue
   }
@@ -71,7 +71,7 @@ class MutableJavaByte()
     * @throws NumberFormatException if the string cannot be parsed into a byte
     * @since 2.5
     */
-  def this(value: String) {
+  def this(value: String) = {
     this()
     this.value = JavaByte.parseByte(value)
   }
@@ -328,7 +328,7 @@ class MutableJavaByte()
     *
     * @return a suitable hash code
     */
-  override def hashCode: Int = value
+  override def hashCode: Int = value.toInt
 
   /**
     * Compares this mutable to another in ascending order.
@@ -343,5 +343,5 @@ class MutableJavaByte()
     *
     * @return the mutable value as a string
     */
-  override def toString: String = String.valueOf(value)
+  override def toString: String = String.valueOf(value.toInt)
 }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableDouble.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableDouble.scala
@@ -42,7 +42,7 @@ class MutableJavaDouble()
     *
     * @param value the initial value to store
     */
-  def this(value: Double) {
+  def this(value: Double) = {
     this()
     this.value = value
   }
@@ -53,7 +53,7 @@ class MutableJavaDouble()
     * @param value the initial value to store, not null
     * @throws NullPointerException if the object is null
     */
-  def this(value: Number) {
+  def this(value: Number) = {
     this()
     this.value = value.doubleValue
   }
@@ -65,7 +65,7 @@ class MutableJavaDouble()
     * @throws NumberFormatException if the string cannot be parsed into a double
     * @since 2.5
     */
-  def this(value: String) {
+  def this(value: String) = {
     this()
     this.value = JavaDouble.parseDouble(value)
   }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableFloat.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableFloat.scala
@@ -42,7 +42,7 @@ class MutableJavaFloat()
     *
     * @param value the initial value to store
     */
-  def this(value: JavaFloat) {
+  def this(value: JavaFloat) = {
     this()
     this.value = value
   }
@@ -53,7 +53,7 @@ class MutableJavaFloat()
     * @param value the initial value to store, not null
     * @throws NullPointerException if the object is null
     */
-  def this(value: Number) {
+  def this(value: Number) = {
     this()
     this.value = value.floatValue
   }
@@ -65,7 +65,7 @@ class MutableJavaFloat()
     * @throws NumberFormatException if the string cannot be parsed into a float
     * @since 2.5
     */
-  def this(value: String) {
+  def this(value: String) = {
     this()
     this.value = JavaFloat.parseFloat(value)
   }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableFloat.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableFloat.scala
@@ -295,7 +295,7 @@ class MutableJavaFloat()
     *
     * @return the numeric value represented by this object after conversion to type float.
     */
-  override def floatValue: JavaFloat = value
+  override def floatValue: Float = value
 
   /**
     * Returns the value of this MutableJavaFloat as a double.

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableInt.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableInt.scala
@@ -267,7 +267,7 @@ class MutableInt()
     *
     * @return the numeric value represented by this object after conversion to type int.
     */
-  override def intValue: Integer = value
+  override def intValue: Int = value
 
   /**
     * Returns the value of this MutableInteger as a long.
@@ -315,7 +315,7 @@ class MutableInt()
     *
     * @return a suitable hash code
     */
-  override def hashCode: Integer = value
+  override def hashCode: Int = value
 
   /**
     * Compares this mutable to another in ascending order.
@@ -323,7 +323,7 @@ class MutableInt()
     * @param other the other mutable to compare to, not null
     * @return negative if this is less, zero if equal, positive if greater
     */
-  override def compareTo(other: MutableInt): Integer = NumberUtils.compare(this.value, other.value)
+  override def compareTo(other: MutableInt): Int = NumberUtils.compare(this.value, other.value)
 
   /**
     * Returns the String value of this mutable.

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableInt.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableInt.scala
@@ -53,7 +53,7 @@ class MutableInt()
     * @param value the initial value to store, not null
     * @throws NullPointerException if the object is null
     */
-  def this(value: Number) {
+  def this(value: Number) = {
     this()
     this.value = value.intValue
   }
@@ -65,7 +65,7 @@ class MutableInt()
     * @throws NumberFormatException if the string cannot be parsed into an int
     * @since 2.5
     */
-  def this(value: String) {
+  def this(value: String) = {
     this()
     this.value = value.toInt
   }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableLong.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableLong.scala
@@ -43,7 +43,7 @@ class MutableJavaLong()
     *
     * @param value the initial value to store
     */
-  def this(value: Long) {
+  def this(value: Long) = {
     this()
     this.value = value
   }
@@ -54,7 +54,7 @@ class MutableJavaLong()
     * @param value the initial value to store, not null
     * @throws NullPointerException if the object is null
     */
-  def this(value: Number) {
+  def this(value: Number) = {
     this()
     this.value = value.longValue
   }
@@ -66,7 +66,7 @@ class MutableJavaLong()
     * @throws NumberFormatException if the string cannot be parsed into a long
     * @since 2.5
     */
-  def this(value: String) {
+  def this(value: String) = {
     this()
     this.value = JavaLong.parseLong(value)
   }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableObject.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableObject.scala
@@ -40,7 +40,7 @@ class MutableObject[T <: AnyRef]()
     *
     * @param value the initial value to store
     */
-  def this(value: T) {
+  def this(value: T) = {
     this()
     this.value = value
   }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableShort.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/mutable/MutableShort.scala
@@ -49,7 +49,7 @@ class MutableShort()
     *
     * @param value the initial value to store
     */
-  def this(value: Short) {
+  def this(value: Short) = {
     this()
     this.value = value
   }
@@ -60,7 +60,7 @@ class MutableShort()
     * @param value the initial value to store, not null
     * @throws NullPointerException if the object is null
     */
-  def this(value: Number) {
+  def this(value: Number) = {
     this()
     this.value = value.shortValue
   }
@@ -72,7 +72,7 @@ class MutableShort()
     * @throws NumberFormatException if the string cannot be parsed into a short
     * @since 2.5
     */
-  def this(value: String) {
+  def this(value: String) = {
     this()
     this.value = JavaShort.parseShort(value)
   }
@@ -344,5 +344,5 @@ class MutableShort()
     *
     * @return the mutable value as a string
     */
-  override def toString: String = String.valueOf(value)
+  override def toString: String = String.valueOf(value.toInt)
 }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/AggregateTranslator.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/AggregateTranslator.scala
@@ -19,7 +19,6 @@ package org.apache.commons.lang3.text.translate
 
 import java.io.IOException
 import java.io.Writer
-import org.apache.commons.lang3.ArrayUtils
 
 /**
   * Executes a sequence of translators one after the other. Execution ends whenever

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/CharSequenceTranslator.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/CharSequenceTranslator.scala
@@ -100,20 +100,20 @@ import java.util.Locale
       val consumed = translate(input, pos, out)
       if (consumed == 0) { // inlined implementation of Character.toChars(Character.codePointAt(input, pos))
         // avoids allocating temp char arrays and duplicate checks
-        val c1 = input.charAt(pos)
-        out.write(c1)
+        val c1: Char = input.charAt(pos)
+        out.write(c1.toInt)
         pos += 1
         if (Character.isHighSurrogate(c1) && pos < len) {
-          val c2 = input.charAt(pos)
+          val c2: Char = input.charAt(pos)
           if (Character.isLowSurrogate(c2)) {
-            out.write(c2)
+            out.write(c2.toInt)
             pos += 1
           }
         }
       } else {
         // contract with translators is that they have to understand codepoints
         // and they just took care of a surrogate pair
-        for (pt <- 0 until consumed) {
+        for (_ <- 0 until consumed) {
           pos += Character.charCount(Character.codePointAt(input, pos))
         }
       }

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/JavaUnicodeEscaper.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/JavaUnicodeEscaper.scala
@@ -93,7 +93,7 @@ package org.apache.commons.lang3.text.translate
   def outsideOf(codepointLow: Int, codepointHigh: Int) = new JavaUnicodeEscaper(codepointLow, codepointHigh, false)
 }
 
-@deprecated class JavaUnicodeEscaper(val below: Int, val above: Int, val between: Boolean)
+@deprecated class JavaUnicodeEscaper( below: Int,  above: Int, between: Boolean)
 
 /**
   * <p>

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/LookupTranslator.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/LookupTranslator.scala
@@ -70,8 +70,8 @@ import java.util
   */
   extends CharSequenceTranslator {
 
-  final private var lookupMap: util.HashMap[String, String] = new util.HashMap[String, String]
-  final private var prefixSet: util.HashSet[Character] = new util.HashSet[Character]
+  final private val lookupMap: util.HashMap[String, String] = new util.HashMap[String, String]
+  final private val prefixSet: util.HashSet[Character] = new util.HashSet[Character]
   final private var shortest = 0
   final private var longest = 0
 

--- a/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/UnicodeEscaper.scala
+++ b/apache-commons-lang3/shared/src/main/scala/org/apache/commons/lang3/text/translate/UnicodeEscaper.scala
@@ -80,7 +80,7 @@ import java.io.Writer
   /**
     * <p>Constructs a {@code UnicodeEscaper} for all characters. </p>
     */
-  def this() {
+  def this() = {
     this(0, Integer.MAX_VALUE, true)
   }
 
@@ -95,10 +95,10 @@ import java.io.Writer
     if (codepoint > 0xffff) out.write(toUtf16Escape(codepoint))
     else {
       out.write("\\u")
-      out.write(HEX_DIGITS((codepoint >> 12) & 15))
-      out.write(HEX_DIGITS((codepoint >> 8) & 15))
-      out.write(HEX_DIGITS((codepoint >> 4) & 15))
-      out.write(HEX_DIGITS(codepoint & 15))
+      out.write(HEX_DIGITS((codepoint >> 12) & 15).toInt)
+      out.write(HEX_DIGITS((codepoint >> 8) & 15).toInt)
+      out.write(HEX_DIGITS((codepoint >> 4) & 15).toInt)
+      out.write(HEX_DIGITS(codepoint & 15).toInt)
     }
     true
   }

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val sharedSettings = Seq(
   }),
 
   // Turning off fatal warnings for doc generation
-  scalacOptions.in(Compile, doc) ~= filterConsoleScalacOptions,
+//  scalacOptions.in(Compile, doc) ~= filterConsoleScalacOptions,
   // Silence all warnings from src_managed files
   scalacOptions += "-P:silencer:pathFilters=.*[/]src_managed[/].*",
 
@@ -267,7 +267,7 @@ lazy val site = project.in(file("site"))
       ),
       micrositeCompilingDocsTool := WithMdoc,
       fork in mdoc := true,
-      scalacOptions.in(Tut) ~= filterConsoleScalacOptions,
+//      scalacOptions.in(Tut) ~= filterConsoleScalacOptions,
       libraryDependencies += "com.47deg" %% "github4s" % GitHub4sVersion,
       micrositePushSiteWith := GitHub4s,
       micrositeGithubToken := sys.env.get("GITHUB_TOKEN"),

--- a/build.sbt
+++ b/build.sbt
@@ -321,6 +321,7 @@ lazy val apacheCommonsLang3StringUtils = crossProject(JSPlatform, JVMPlatform)
       "org.scalatestplus" %%% "scalacheck-1-14"  % ScalaTestPlusVersion % Test,
       "org.scalacheck"    %%% "scalacheck"       % ScalaCheckVersion % Test,
     ),
+    scalacOptions -= "-deprecation",
     headerLicense := Some(HeaderLicense.Custom(
       s"""|Licensed to the Apache Software Foundation (ASF) under one or more
           |contributor license agreements.  See the NOTICE file distributed with

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("com.geirsson"              % "sbt-ci-release"                % "1.
 addSbtPlugin("com.github.tkawachi"       % "sbt-doctest"                   % "0.9.6")
 addSbtPlugin("com.typesafe"              % "sbt-mima-plugin"               % "0.7.0")
 addSbtPlugin("de.heikoseeberger"         % "sbt-header"                    % "5.6.0")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"                  % "0.1.13")
+//addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"                  % "0.1.13")
 addSbtPlugin("org.portable-scala"        % "sbt-scala-native-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala"        % "sbt-scalajs-crossproject"      % "1.0.0")
 addSbtPlugin("org.scala-js"              % "sbt-scalajs"                   % ScalaJSVersion)


### PR DESCRIPTION
* tpolecat plugin is disabled to suppress compile erros, especially "unused" errors. I think such errors are just annoying on current phase.
* Typing issues are resolved. Mostly, `Any` to `AnyRef`, which responds to `java.lang.Object` in original definition.
* Unnecessary `val` modifiers in constructor are removed.




Once this get reviewed and merged, I will consider to port test codes into Scala.
(Which scala test framework do you prefer?  If no preference, I will recoommend munit that supports Scala/Scala-js/Scala-native)